### PR TITLE
feat: add middleware support for request interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # reqwest
 
 [![Go Version](https://img.shields.io/badge/Go-1.23.4-blue.svg)](https://golang.org/)
-[![Coverage](https://img.shields.io/badge/Coverage-96.6%25-green.svg)](coverage.html)
+[![Coverage](https://img.shields.io/badge/Coverage-97.1%25-green.svg)](coverage.html)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 A simple and elegant HTTP client library for Go
@@ -33,21 +33,21 @@ package main
 import (
     "fmt"
     "io"
-    
+
     "github.com/rbhujang/reqwest"
 )
 
 func main() {
     // Create a client
     client := reqwest.NewClientBuilder().Build()
-    
+
     // Make a GET request
     resp, err := client.Get("https://api.github.com/users/octocat")
     if err != nil {
         panic(err)
     }
     defer resp.Body().Close()
-    
+
     // Read response
     body, _ := io.ReadAll(resp.Body())
     fmt.Printf("Status: %d\n", resp.StatusCode())
@@ -88,28 +88,35 @@ fmt.Printf("Status: %d\n", resp.StatusCode())
 ### ClientBuilder
 
 #### `NewClientBuilder() *ClientBuilder`
+
 Creates a new client builder.
 
 #### `WithBaseURL(url string) *ClientBuilder`
+
 Sets the base URL for the client. Trailing slashes are automatically trimmed.
 
 #### `Build() Client`
+
 Builds and returns the configured client.
 
 ### Client
 
 #### `Get(url string) (*Response, error)`
+
 Performs a GET request to the specified URL.
 
 #### `Post(url string, body []byte) (*Response, error)`
+
 Performs a POST request to the specified URL with the given body.
 
 ### Response
 
 #### `StatusCode() int`
+
 Returns the HTTP status code of the response.
 
 #### `Body() io.ReadCloser`
+
 Returns the response body as a ReadCloser. Remember to close it when done.
 
 ## URL Handling

--- a/builder.go
+++ b/builder.go
@@ -6,11 +6,14 @@ import (
 )
 
 type ClientBuilder struct {
-	baseURL string
+	baseURL     string
+	middlewares []Middleware
 }
 
 func NewClientBuilder() *ClientBuilder {
-	return &ClientBuilder{}
+	return &ClientBuilder{
+		middlewares: make([]Middleware, 0),
+	}
 }
 
 func (cb *ClientBuilder) WithBaseURL(url string) *ClientBuilder {
@@ -18,13 +21,19 @@ func (cb *ClientBuilder) WithBaseURL(url string) *ClientBuilder {
 	return cb
 }
 
+func (cb *ClientBuilder) WithMiddleware(middleware Middleware) *ClientBuilder {
+	cb.middlewares = append(cb.middlewares, middleware)
+	return cb
+}
+
 func (cb *ClientBuilder) Build() Client {
 	c := &client{
-		httpClient: http.DefaultClient,
+		httpClient:  http.DefaultClient,
+		middlewares: make([]Middleware, len(cb.middlewares)),
 	}
 	if cb.baseURL != "" {
 		c.baseURL = cb.baseURL
 	}
-
+	copy(c.middlewares, cb.middlewares)
 	return c
 }

--- a/client.go
+++ b/client.go
@@ -20,8 +20,9 @@ type Client interface {
 }
 
 type client struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL     string
+	httpClient  *http.Client
+	middlewares []Middleware
 }
 
 func (c *client) Get(url string) (*Response, error) {
@@ -42,7 +43,11 @@ func (c *client) execute(ctx context.Context, url, method string, body io.Reader
 	if err != nil {
 		return nil, fmt.Errorf("failed to make http request: %v", err)
 	}
-
+	for _, middleware := range c.middlewares {
+		if err := middleware(req); err != nil {
+			return nil, fmt.Errorf("middleware error: %v", err)
+		}
+	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to do http request: %v", err)

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,5 @@
+package reqwest
+
+import "net/http"
+
+type Middleware func(*http.Request) error


### PR DESCRIPTION
Add composable middleware system that allows users to intercept and modify HTTP requests before
  execution. Middlewares can be chained together and are executed in the order they were added.